### PR TITLE
fix: do not type internal PiwaBadInputError

### DIFF
--- a/playground/index.ts
+++ b/playground/index.ts
@@ -42,4 +42,31 @@ import piwa from '../src';
   });
   console.log('[demo 6] Error from sync function:', demo6Error);
   console.log('[demo 6] Where is the data?', demo6Data);
+
+  // ----
+
+  // Piwa works great with typings too
+  // You can type data
+  interface Data {
+    key: string;
+  }
+  const { data: demo7Data } = await piwa<Data>(() => {
+    return { key: 'value' };
+  });
+  console.log('[demo 7] Data is properly typed:', demo7Data?.key);
+
+  // And you can type error
+  class BigError extends Error {
+    data: 'I’m the big error data';
+  }
+  const { error: demo8Error } = await piwa<null, BigError>(() => {
+    throw new BigError('Boom!');
+  });
+  console.log('[demo 8] Error is properly typed too:', demo8Error?.data);
+
+  // ----
+  // If the input ins incorrect, piwa emits an internal error: PiwaBadInputError
+  // @ts-expect-error We deliberately pass a wrong input
+  const { error: demo9Error } = await piwa({});
+  console.log('[demo 9] Error is:', demo9Error);
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@
  * Promise wrapper that returns data or error in an object format
  * @param promiseOrFunction - Any promise, async function, or function
  */
-async function piwa<Data, Err extends Error>(
+async function piwa<Data, Err extends Error = Error>(
   promiseOrFunction: PiwaArgs<Data>
-): PiwaResponse<Data, PiwaError<Err>> {
+): PiwaResponse<Data, Err> {
   const isValidInput =
     typeof promiseOrFunction === 'function' ||
     promiseOrFunction instanceof Promise;
@@ -13,7 +13,7 @@ async function piwa<Data, Err extends Error>(
     console.error(
       '[Piwa] Invalid argument. Must be: a promise, an async function, or a function'
     );
-    return { data: null, error: new PiwaBadInputError() };
+    return { data: null, error: new PiwaBadInputError() as Err };
   }
 
   const _promise: Promise<Data> =
@@ -41,7 +41,6 @@ export class PiwaBadInputError extends Error {
   }
 }
 
-type PiwaError<Err = Error> = Err | PiwaBadInputError;
 type PiwaArgs<Data> = Promise<Data> | (() => Promise<Data>) | (() => Data);
 
 export type PiwaResponse<Data, Err extends Error> = Promise<

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -32,7 +32,7 @@ test('returns error for a failing promise', async t => {
 
   t.is(data, null);
   t.is(error instanceof Error, true);
-  t.is(error.message, 'ko!');
+  t.is(error?.message, 'ko!');
 });
 
 test('returns a PiwaBadInput error if argument is not allowed', async t => {


### PR DESCRIPTION
- As this error is seen only in *runtime*, it is good to make it a custom error with class extension, but should not type the error which is returned by piwa because we will always have type mismatches, and it will not serve as a type check / type spell. Moreover, this error is fired only when the input is incorrect, which could appear in non-TS environments (or poorly typed ones).